### PR TITLE
Remove 2024-specific constants for move to common

### DIFF
--- a/src/main/cpp/subsystems/DriveSubsystem.cpp
+++ b/src/main/cpp/subsystems/DriveSubsystem.cpp
@@ -90,7 +90,7 @@ void DriveSubsystem::Periodic() {
                                  GetModulePositions());
     logDrivebase();
 
-    auto visionPoses = m_vision->UpdateEstimatedGlobalPose(poseEstimator);
+    m_vision->UpdateEstimatedGlobalPose(poseEstimator, true);
 
     auto updatedPose = poseEstimator.GetEstimatedPosition();
     // https://github.com/Hemlock5712/2023-Robot/blob/dd5ac64587a3839492cfdb0a28d21677d465584a/src/main/java/frc/robot/subsystems/PoseEstimatorSubsystem.java#L149

--- a/src/main/cpp/utils/TurnToPose.cpp
+++ b/src/main/cpp/utils/TurnToPose.cpp
@@ -4,20 +4,14 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <frc/trajectory/TrajectoryGenerator.h>
 
-#include "Constants.h"
-
 TurnToPose::TurnToPose(TurnToPoseConfig config,
                        std::function<frc::Pose2d()> poseGetter,
                        std::function<frc::Field2d*()> fieldGetter)
     : m_config{config}, m_poseGetter{poseGetter}, m_fieldGetter{fieldGetter} {
-  using namespace AutoConstants;
-
-  auto xController = frc::PIDController(TurnToPoseConstants::kTurnTranslationP,
-                                        TurnToPoseConstants::kTurnTranslationI,
-                                        TurnToPoseConstants::kTurnTranslationD);
-  auto yController = frc::PIDController(TurnToPoseConstants::kTurnTranslationP,
-                                        TurnToPoseConstants::kTurnTranslationI,
-                                        TurnToPoseConstants::kTurnTranslationD);
+  auto xController = frc::PIDController(
+      m_config.translationP, m_config.translationI, m_config.translationD);
+  auto yController = frc::PIDController(
+      m_config.translationP, m_config.translationI, m_config.translationD);
   auto profile = m_config.rotationConstraints;
   auto profiledController = frc::ProfiledPIDController<units::radians>(
       m_config.turnP, m_config.turnI, m_config.turnD, profile);

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -167,10 +167,35 @@ class RobotContainer {
                           [this] { return m_drive.GetPose(); },
                           [this] { return m_drive.GetField(); }};
 
+  photon::PhotonPoseEstimator poseFront{
+      // layout
+      VisionConstants::kTagLayout,
+      // strategy
+      VisionConstants::kPoseStrategy,
+      // camera name
+      photon::PhotonCamera{VisionConstants::kFrontCamera},
+      // offsets
+      VisionConstants::kRobotToCam};
+
+  photon::PhotonPoseEstimator poseRear{
+      // layout
+      VisionConstants::kTagLayout,
+      // strategy
+      VisionConstants::kPoseStrategy,
+      // camera name
+      photon::PhotonCamera{VisionConstants::kRearCamera},
+      // offsets
+      VisionConstants::kRobotToCam2};
+
+  std::vector<Vision::PhotonCameraEstimator> poseCameras{
+      Vision::PhotonCameraEstimator(poseFront),
+      Vision::PhotonCameraEstimator(poseRear),
+  };
+
   void ConfigureAutoBindings();
 #endif
 
-  Vision m_vision;
+  Vision m_vision{poseCameras};
 
   void RegisterAutos();
   void ConfigureButtonBindings();

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -162,6 +162,12 @@ class RobotContainer {
                            TurnToPoseConstants::kTurnI,
                            // Turn D
                            TurnToPoseConstants::kTurnD,
+                           // Translation P
+                           TurnToPoseConstants::kTurnTranslationP,
+                           // Translation I
+                           TurnToPoseConstants::kTurnTranslationI,
+                           // Translation D
+                           TurnToPoseConstants::kTurnTranslationD,
                            // Pose tolerance
                            TurnToPoseConstants::kPoseTolerance},
                           [this] { return m_drive.GetPose(); },

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -18,6 +18,8 @@
 #include <pathplanner/lib/auto/NamedCommands.h>
 #include <pathplanner/lib/commands/PathPlannerAuto.h>
 
+#include <vector>
+
 #include "Constants.h"
 #include "autos/AutoFactory.h"
 #include "subsystems/ArmSubsystem.h"

--- a/src/main/include/moduledrivers/ConnectorX.h
+++ b/src/main/include/moduledrivers/ConnectorX.h
@@ -312,7 +312,8 @@ struct CachedDevice {
 class ConnectorXBoard : public frc2::SubsystemBase {
  public:
   explicit ConnectorXBoard(uint8_t slaveAddress,
-                           frc::I2C::Port port = frc::I2C::kMXP);
+                           frc::I2C::Port port = frc::I2C::kMXP,
+                           units::second_t connectorXDelay = 0.002_s);
 
   /**
    * @brief Start communication with the controller
@@ -503,6 +504,7 @@ class ConnectorXBoard : public frc2::SubsystemBase {
   std::unique_ptr<frc::I2C> _i2c;
   uint8_t _slaveAddress;
   LedPort _currentLedPort = LedPort::P0;
+  units::second_t _delay;
   CachedDevice m_device;
   Commands::CommandType _lastCommand;
   hal::SimDevice m_simDevice;

--- a/src/main/include/utils/TurnToPose.h
+++ b/src/main/include/utils/TurnToPose.h
@@ -21,6 +21,9 @@ class TurnToPose : public ITurnToTarget {
     double turnP;
     double turnI;
     double turnD;
+    double translationP;
+    double translationI;
+    double translationD;
     /// @brief A pose within this range will be considered at-goal
     frc::Pose2d poseTolerance;
   };
@@ -65,7 +68,8 @@ class TurnToPose : public ITurnToTarget {
 
   inline units::degree_t GetTargetHeading() const { return m_targetHeading; }
 
-  static double NormalizeScalar(double x, double from_min, double from_max, double to_min, double to_max) {
+  static double NormalizeScalar(double x, double from_min, double from_max,
+                                double to_min, double to_max) {
     return (x - from_min) * (to_max - to_min) / (from_max - from_min) + to_min;
   }
 

--- a/src/main/include/utils/Vision.h
+++ b/src/main/include/utils/Vision.h
@@ -26,7 +26,7 @@ class Vision {
     std::shared_ptr<photon::PhotonCamera> camera;
   };
 
-  Vision(std::vector<PhotonCameraEstimator>& estms)
+  explicit Vision(std::vector<PhotonCameraEstimator>& estms)
       : m_cameraEstimators{estms} {
     for (auto& est : m_cameraEstimators) {
       est.estimator.SetMultiTagFallbackStrategy(


### PR DESCRIPTION
Removes the inclusion of constants/lil's scoots-specific things from

- Vision
- Turn to pose
- Connector-X driver